### PR TITLE
Removal of APS portal, SIMS, Timesoft from Staff submenu list on navigation bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,16 +11,10 @@ links:
   - title: Staff
     url: https://sites.google.com/moe.edu.sg/aps-staff/
     sublinks:
-      - title: APS Portal
-        url: https://intranet.apsch.edu.sg/
       - title: APS Staff Google Site
         url: https://sites.google.com/moe.edu.sg/aps-staff/
       - title: Opal 2.0
         url: https://idm.opal2.moe.edu.sg/
-      - title: SIMS
-        url: https://sims.apsch.edu.sg/
-      - title: Timesoft
-        url: https://hr.apsch.edu.sg/TimeSolution/Signin.aspx
   - title: The ART
     collection: the-art
   - title: Partnerships


### PR DESCRIPTION
Removal of the APS portal, SIMS, Timesoft as MOE HQ has alerted high vulnerability risk on our intranet. After speaking to our vendor, they explained it is because of the link to the intranet on our public website.